### PR TITLE
group hardlinks together

### DIFF
--- a/act_dedupefiles.c
+++ b/act_dedupefiles.c
@@ -49,6 +49,9 @@ extern void dedupefiles(file_t * restrict files)
   int fd;
   int ret, status, readonly;
 
+  fprintf(stderr, "chosen action does not support multiple filenames yet - error out rather than breaking anything!\n");
+  exit(EXIT_FAILURE);
+
   LOUD(fprintf(stderr, "\nRunning dedupefiles()\n");)
 
   /* Find the largest dupe set, alloc space to hold structs for it */

--- a/act_deletefiles.c
+++ b/act_deletefiles.c
@@ -120,7 +120,7 @@ preserve_none:
             continue;
           }
 #endif
-          if (file_has_changed(dupelist[x])) {
+          if (file_has_changed(dupelist[x]->filename)) {
             printf("   [!] "); fwprint(stdout, dupelist[x]->filename->d_name, 0);
             printf("-- file changed since being scanned\n");
 #ifdef UNICODE

--- a/act_deletefiles.c
+++ b/act_deletefiles.c
@@ -40,7 +40,7 @@ extern void deletefiles(file_t *files, int prompt, FILE *tty)
       dupelist[counter] = files;
 
       if (prompt) {
-        printf("[%u] ", counter); fwprint(stdout, files->d_name, 1);
+        printf("[%u] ", counter); fwprint(stdout, files->filename->d_name, 1);
       }
 
       tmpfile = files->duplicates;
@@ -48,7 +48,7 @@ extern void deletefiles(file_t *files, int prompt, FILE *tty)
       while (tmpfile) {
         dupelist[++counter] = tmpfile;
         if (prompt) {
-          printf("[%u] ", counter); fwprint(stdout, tmpfile->d_name, 1);
+          printf("[%u] ", counter); fwprint(stdout, tmpfile->filename->d_name, 1);
         }
         tmpfile = tmpfile->duplicates;
       }
@@ -111,26 +111,26 @@ preserve_none:
 
       for (x = 1; x <= counter; x++) {
         if (preserve[x]) {
-          printf("   [+] "); fwprint(stdout, dupelist[x]->d_name, 1);
+          printf("   [+] "); fwprint(stdout, dupelist[x]->filename->d_name, 1);
         } else {
 #ifdef UNICODE
           if (!M2W(dupelist[x]->d_name, wstr)) {
-            printf("   [!] "); fwprint(stdout, dupelist[x]->d_name, 0);
+            printf("   [!] "); fwprint(stdout, dupelist[x]->filename->d_name, 0);
             printf("-- MultiByteToWideChar failed\n");
             continue;
           }
 #endif
           if (file_has_changed(dupelist[x])) {
-            printf("   [!] "); fwprint(stdout, dupelist[x]->d_name, 0);
+            printf("   [!] "); fwprint(stdout, dupelist[x]->filename->d_name, 0);
             printf("-- file changed since being scanned\n");
 #ifdef UNICODE
           } else if (DeleteFile(wstr) != 0) {
 #else
-          } else if (remove(dupelist[x]->d_name) == 0) {
+          } else if (remove(dupelist[x]->filename->d_name) == 0) {
 #endif
-            printf("   [-] "); fwprint(stdout, dupelist[x]->d_name, 1);
+            printf("   [-] "); fwprint(stdout, dupelist[x]->filename->d_name, 1);
           } else {
-            printf("   [!] "); fwprint(stdout, dupelist[x]->d_name, 0);
+            printf("   [!] "); fwprint(stdout, dupelist[x]->filename->d_name, 0);
             printf("-- unable to delete file\n");
           }
         }

--- a/act_deletefiles.c
+++ b/act_deletefiles.c
@@ -23,6 +23,9 @@ extern void deletefiles(file_t *files, int prompt, FILE *tty)
   unsigned int number, sum, max, x;
   size_t i;
 
+  fprintf(stderr, "chosen action does not support multiple filenames yet - error out rather than breaking anything!\n");
+  exit(EXIT_FAILURE);
+
   groups = get_max_dupes(files, &max, NULL);
 
   max++;

--- a/act_linkfiles.c
+++ b/act_linkfiles.c
@@ -30,6 +30,8 @@ extern void linkfiles(file_t *files, const int hard)
   static char rel_path[PATHBUF_SIZE];
 #endif
   static char temp_path[PATHBUF_SIZE];
+  static filename_t * restrict dupename;
+  static filename_t * restrict srcname;
 
   LOUD(fprintf(stderr, "Running linkfiles(%d)\n", hard);)
   curfile = files;
@@ -96,209 +98,224 @@ extern void linkfiles(file_t *files, const int hard)
         exit(EXIT_FAILURE);
 #endif
       }
+
+      srcname = srcfile->filename;
+
       if (!ISFLAG(flags, F_HIDEPROGRESS)) {
-        printf("[SRC] "); fwprint(stdout, srcfile->filename->d_name, 1);
+        printf("[SRC] "); fwprint(stdout, srcname->d_name, 1);
       }
       for (; x <= counter; x++) {
-        if (hard == 1) {
-          /* Can't hard link files on different devices */
-          if (srcfile->device != dupelist[x]->device) {
-            fprintf(stderr, "warning: hard link target on different device, not linking:\n-//-> ");
-            fwprint(stderr, dupelist[x]->filename->d_name, 1);
-            continue;
-          } else {
-            /* The devices for the files are the same, but we still need to skip
-             * anything that is already hard linked (-L and -H both set) */
-            if (srcfile->inode == dupelist[x]->inode) {
-              /* Don't show == arrows when not matching against other hard links */
-              if (ISFLAG(flags, F_CONSIDERHARDLINKS))
-                if (!ISFLAG(flags, F_HIDEPROGRESS)) {
-                  printf("-==-> "); fwprint(stdout, dupelist[x]->filename->d_name, 1);
-                }
-            continue;
+	/* iterate over all filenames */
+	for (dupename = dupelist[x]->filename; dupename; dupename = dupename->next) {
+          if (hard == 1) {
+            /* Can't hard link files on different devices */
+            if (srcfile->device != dupelist[x]->device) {
+              fprintf(stderr, "warning: hard link target on different device, not linking:\n-//-> ");
+              fwprint(stderr, dupename->d_name, 1);
+              continue;
+            } else {
+              /* The devices for the files are the same, but we still need to skip
+               * anything that is already hard linked (-L and -H both set) */
+              if (srcfile->inode == dupelist[x]->inode) {
+                /* Don't show == arrows when not matching against other hard links */
+                if (ISFLAG(flags, F_CONSIDERHARDLINKS))
+                  if (!ISFLAG(flags, F_HIDEPROGRESS)) {
+                    printf("-==-> "); fwprint(stdout, dupename->d_name, 1);
+                  }
+                continue;
+              }
             }
-          }
-        } else {
-          /* Symlink prerequisite check code can go here */
-          /* Do not attempt to symlink a file to itself or to another symlink */
+          } else {
+            /* Symlink prerequisite check code can go here */
+            /* Do not attempt to symlink a file to itself or to another symlink */
 #ifndef NO_SYMLINKS
-          if (ISFLAG(dupelist[x]->flags, F_IS_SYMLINK) &&
-              ISFLAG(dupelist[symsrc]->flags, F_IS_SYMLINK)) continue;
-          if (x == symsrc) continue;
+            if (ISFLAG(dupelist[x]->flags, F_IS_SYMLINK) &&
+                ISFLAG(dupelist[symsrc]->flags, F_IS_SYMLINK)) continue;
+            if (x == symsrc) continue;
 #endif
-        }
+          }
 #ifdef UNICODE
-        if (!M2W(dupelist[x]->filename->d_name, wname)) {
-          fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          continue;
-        }
+          if (!M2W(dupename->d_name, wname)) {
+            fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, dupename->d_name, 1);
+            continue;
+          }
 #endif /* UNICODE */
 
-        /* Do not attempt to hard link files for which we don't have write access */
+          /* Do not attempt to hard link files for which we don't have write access */
 #ifdef ON_WINDOWS
-        if (dupelist[x]->mode & FILE_ATTRIBUTE_READONLY)
+          if (dupelist[x]->mode & FILE_ATTRIBUTE_READONLY)
 #else
-        if (access(dupelist[x]->filename->d_name, W_OK) != 0)
+          if (access(dupename->d_name, W_OK) != 0)
 #endif
-        {
-          fprintf(stderr, "warning: link target is a read-only file, not linking:\n-//-> ");
-          fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          continue;
-        }
-        /* Check file pairs for modification before linking */
-        /* Safe linking: don't actually delete until the link succeeds */
-        i = file_has_changed(srcfile);
-        if (i) {
-          fprintf(stderr, "warning: source file modified since scanned; changing source file:\n[SRC] ");
-          fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          LOUD(fprintf(stderr, "file_has_changed: %d\n", i);)
-          srcfile = dupelist[x];
-          continue;
-        }
-        if (file_has_changed(dupelist[x])) {
-          fprintf(stderr, "warning: target file modified since scanned, not linking:\n-//-> ");
-          fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          continue;
-        }
-#ifdef ON_WINDOWS
-        /* For Windows, the hard link count maximum is 1023 (+1); work around
-         * by skipping linking or changing the link source file as needed */
-        if (win_stat(srcfile->filename->d_name, &ws) != 0) {
-          fprintf(stderr, "warning: win_stat() on source file failed, changing source file:\n[SRC] ");
-          fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          srcfile = dupelist[x];
-          continue;
-        }
-        if (ws.nlink >= 1024) {
-          fprintf(stderr, "warning: maximum source link count reached, changing source file:\n[SRC] ");
-          srcfile = dupelist[x];
-          continue;
-        }
-        if (win_stat(dupelist[x]->filename->d_name, &ws) != 0) continue;
-        if (ws.nlink >= 1024) {
-          fprintf(stderr, "warning: maximum destination link count reached, skipping:\n-//-> ");
-          fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          continue;
-        }
-#endif
-
-        /* Make sure the name will fit in the buffer before trying */
-        name_len = strlen(dupelist[x]->filename->d_name) + 14;
-        if (name_len > PATHBUF_SIZE) continue;
-        /* Assemble a temporary file name */
-        strcpy(temp_path, dupelist[x]->filename->d_name);
-        strcat(temp_path, ".__jdupes__.tmp");
-        /* Rename the source file to the temporary name */
-#ifdef UNICODE
-        if (!M2W(temp_path, wname2)) {
-          fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, srcfile->filename->d_name, 1);
-          continue;
-        }
-        i = MoveFile(wname, wname2) ? 0 : 1;
-#else
-        i = rename(dupelist[x]->filename->d_name, temp_path);
-#endif
-        if (i != 0) {
-          fprintf(stderr, "warning: cannot move link target to a temporary name, not linking:\n-//-> ");
-          fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          /* Just in case the rename succeeded yet still returned an error, roll back the rename */
-#ifdef UNICODE
-          MoveFile(wname2, wname);
-#else
-          rename(temp_path, dupelist[x]->filename->d_name);
-#endif
-          continue;
-        }
-
-        /* Create the desired hard link with the original file's name */
-        errno = 0;
-#ifdef ON_WINDOWS
- #ifdef UNICODE
-        if (!M2W(srcfile->filename->d_name, wname2)) {
-          fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, srcfile->filename->d_name, 1);
-          continue;
-        }
-        if (CreateHardLinkW((LPCWSTR)wname, (LPCWSTR)wname2, NULL) == TRUE) success = 1;
- #else
-        if (CreateHardLink(dupelist[x]->filename->d_name, srcfile->filename->d_name, NULL) == TRUE) success = 1;
- #endif
-#else
-        success = 0;
-        if (hard) {
-          if (link(srcfile->filename->d_name, dupelist[x]->filename->d_name) == 0) success = 1;
- #ifdef NO_SYMLINKS
-        }
- #else
-        } else {
-          i = make_relative_link_name(srcfile->filename->d_name, dupelist[x]->filename->d_name, rel_path);
-          LOUD(fprintf(stderr, "symlink GRN: %s to %s = %s\n", srcfile->filename->d_name, dupelist[x]->filename->d_name, rel_path));
-          if (i < 0) {
-            fprintf(stderr, "warning: make_relative_link_name() failed (%d)\n", i);
-          } else if (i == 1) {
-            fprintf(stderr, "warning: files to be linked have the same canonical path; not linking\n");
-          } else if (symlink(rel_path, dupelist[x]->filename->d_name) == 0) success = 1;
-        }
- #endif /* NO_SYMLINKS */
-#endif /* ON_WINDOWS */
-        if (success) {
-          if (!ISFLAG(flags, F_HIDEPROGRESS)) printf("%s %s\n", (hard ? "---->" : "-@@->"), dupelist[x]->filename->d_name);
-        } else {
-          /* The link failed. Warn the user and put the link target back */
-          if (!ISFLAG(flags, F_HIDEPROGRESS)) {
-            printf("-//-> "); fwprint(stderr, dupelist[x]->filename->d_name, 1);
-          }
-          fprintf(stderr, "warning: unable to link '"); fwprint(stderr, dupelist[x]->filename->d_name, 0);
-          fprintf(stderr, "' -> '"); fwprint(stderr, srcfile->filename->d_name, 0);
-          fprintf(stderr, "': %s\n", strerror(errno));
-#ifdef UNICODE
-          if (!M2W(temp_path, wname2)) {
-            fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, temp_path, 1);
+          {
+            fprintf(stderr, "warning: link target is a read-only file, not linking:\n-//-> ");
+            fwprint(stderr, dupename->d_name, 1);
             continue;
           }
-          i = MoveFile(wname2, wname) ? 0 : 1;
+          /* Check file pairs for modification before linking */
+          /* Safe linking: don't actually delete until the link succeeds */
+          i = file_has_changed(srcname);
+          if (i) {
+            fprintf(stderr, "warning: source file modified since scanned; changing source file:\n[SRC] ");
+            fwprint(stderr, srcname->d_name, 1);
+            LOUD(fprintf(stderr, "file_has_changed: %d\n", i);)
+              srcfile = dupelist[x];
+            continue;
+          }
+          if (file_has_changed(dupename)) {
+            fprintf(stderr, "warning: target file modified since scanned, not linking:\n-//-> ");
+            fwprint(stderr, dupename->d_name, 1);
+            continue;
+          }
+#ifdef ON_WINDOWS
+          /* For Windows, the hard link count maximum is 1023 (+1); work around
+           * by skipping linking or changing the link source file as needed */
+          if (win_stat(srcname->d_name, &ws) != 0) {
+            fprintf(stderr, "warning: win_stat() on source file failed, changing source file:\n[SRC] ");
+            fwprint(stderr, dupename->d_name, 1);
+            srcfile = dupelist[x];
+            srcname = dupename;
+            continue;
+          }
+          if (ws.nlink >= 1024) {
+            fprintf(stderr, "warning: maximum source link count reached, changing source file:\n[SRC] ");
+            srcfile = dupelist[x];
+            srcname = dupename;
+            continue;
+          }
+          if (win_stat(dupename->d_name, &ws) != 0) continue;
+          if (ws.nlink >= 1024) {
+            fprintf(stderr, "warning: maximum destination link count reached, skipping:\n-//-> ");
+            fwprint(stderr, dupename->d_name, 1);
+            continue;
+          }
+#endif
+
+          /* Make sure the name will fit in the buffer before trying */
+          name_len = strlen(dupename->d_name) + 14;
+          if (name_len > PATHBUF_SIZE) continue;
+          /* Assemble a temporary file name */
+          strcpy(temp_path, dupename->d_name);
+          strcat(temp_path, ".__jdupes__.tmp");
+          /* Rename the source file to the temporary name */
+#ifdef UNICODE
+          if (!M2W(temp_path, wname2)) {
+            fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, dupename->d_name, 1);
+            continue;
+          }
+          i = MoveFile(wname, wname2) ? 0 : 1;
 #else
-          i = rename(temp_path, dupelist[x]->filename->d_name);
+          i = rename(dupename->d_name, temp_path);
 #endif
           if (i != 0) {
-            fprintf(stderr, "error: cannot rename temp file back to original\n");
-            fprintf(stderr, "original: "); fwprint(stderr, dupelist[x]->filename->d_name, 1);
-            fprintf(stderr, "current:  "); fwprint(stderr, temp_path, 1);
+            fprintf(stderr, "warning: cannot move link target to a temporary name, not linking:\n-//-> ");
+            fwprint(stderr, dupename->d_name, 1);
+            /* Just in case the rename succeeded yet still returned an error, roll back the rename */
+#ifdef UNICODE
+            MoveFile(wname2, wname);
+#else
+            rename(temp_path, dupename->d_name);
+#endif
+            continue;
           }
-          continue;
-        }
 
-        /* Remove temporary file to clean up; if we can't, reverse the linking */
+          /* Create the desired hard link with the original file's name */
+          errno = 0;
+#ifdef ON_WINDOWS
+ #ifdef UNICODE
+          if (!M2W(srcname->d_name, wname2)) {
+            fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, srcname->d_name, 1);
+            continue;
+          }
+          if (CreateHardLinkW((LPCWSTR)wname, (LPCWSTR)wname2, NULL) == TRUE) success = 1;
+ #else
+          if (CreateHardLink(dupename->d_name, srcname->d_name, NULL) == TRUE) success = 1;
+ #endif
+#else
+          success = 0;
+          if (hard) {
+            if (link(srcname->d_name, dupename->d_name) == 0) success = 1;
+ #ifdef NO_SYMLINKS
+          }
+ #else
+          } else {
+            i = make_relative_link_name(srcname->d_name, dupename->d_name, rel_path);
+            LOUD(fprintf(stderr, "symlink GRN: %s to %s = %s\n", srcname->d_name, dupename->d_name, rel_path));
+            if (i < 0) {
+              fprintf(stderr, "warning: make_relative_link_name() failed (%d)\n", i);
+            } else if (i == 1) {
+              fprintf(stderr, "warning: files to be linked have the same canonical path; not linking\n");
+            } else if (symlink(rel_path, dupename->d_name) == 0) success = 1;
+          }
+ #endif /* NO_SYMLINKS */
+#endif /* ON_WINDOWS */
+          if (success) {
+            if (!ISFLAG(flags, F_HIDEPROGRESS)) printf("%s %s\n", (hard ? "---->" : "-@@->"), dupename->d_name);
+#ifndef NO_HARDLINKS
+            if (hard) {
+              /* adjust link counts or the next file_has_changed() will fail */
+              srcfile->nlink++;
+              dupelist[x]->nlink--;
+            }
+#endif
+          } else {
+            /* The link failed. Warn the user and put the link target back */
+            if (!ISFLAG(flags, F_HIDEPROGRESS)) {
+              printf("-//-> "); fwprint(stderr, dupename->d_name, 1);
+            }
+            fprintf(stderr, "warning: unable to link '"); fwprint(stderr, dupename->d_name, 0);
+            fprintf(stderr, "' -> '"); fwprint(stderr, srcname->d_name, 0);
+            fprintf(stderr, "': %s\n", strerror(errno));
+#ifdef UNICODE
+            if (!M2W(temp_path, wname2)) {
+              fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, temp_path, 1);
+              continue;
+            }
+            i = MoveFile(wname2, wname) ? 0 : 1;
+#else
+            i = rename(temp_path, dupename->d_name);
+#endif
+            if (i != 0) {
+              fprintf(stderr, "error: cannot rename temp file back to original\n");
+              fprintf(stderr, "original: "); fwprint(stderr, dupename->d_name, 1);
+              fprintf(stderr, "current:  "); fwprint(stderr, temp_path, 1);
+            }
+            continue;
+          }
+
+          /* Remove temporary file to clean up; if we can't, reverse the linking */
 #ifdef UNICODE
           if (!M2W(temp_path, wname2)) {
             fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, temp_path, 1);
             continue;
           }
-        i = DeleteFile(wname2) ? 0 : 1;
+          i = DeleteFile(wname2) ? 0 : 1;
 #else
-        i = remove(temp_path);
+          i = remove(temp_path);
 #endif
-        if (i != 0) {
-          /* If the temp file can't be deleted, there may be a permissions problem
-           * so reverse the process and warn the user */
-          fprintf(stderr, "\nwarning: can't delete temp file, reverting: ");
-          fwprint(stderr, temp_path, 1);
+          if (i != 0) {
+            /* If the temp file can't be deleted, there may be a permissions problem
+             * so reverse the process and warn the user */
+            fprintf(stderr, "\nwarning: can't delete temp file, reverting: ");
+            fwprint(stderr, temp_path, 1);
 #ifdef UNICODE
-          i = DeleteFile(wname) ? 0 : 1;
+            i = DeleteFile(wname) ? 0 : 1;
 #else
-          i = remove(dupelist[x]->filename->d_name);
+            i = remove(dupename->d_name);
 #endif
-          /* This last error really should not happen, but we can't assume it won't */
-          if (i != 0) fprintf(stderr, "\nwarning: couldn't remove link to restore original file\n");
-          else {
+            /* This last error really should not happen, but we can't assume it won't */
+            if (i != 0) fprintf(stderr, "\nwarning: couldn't remove link to restore original file\n");
+            else {
 #ifdef UNICODE
-            i = MoveFile(wname2, wname) ? 0 : 1;
+              i = MoveFile(wname2, wname) ? 0 : 1;
 #else
-            i = rename(temp_path, dupelist[x]->filename->d_name);
+              i = rename(temp_path, dupename->d_name);
 #endif
-            if (i != 0) {
-              fprintf(stderr, "\nwarning: couldn't revert the file to its original name\n");
-              fprintf(stderr, "original: "); fwprint(stderr, dupelist[x]->filename->d_name, 1);
-              fprintf(stderr, "current:  "); fwprint(stderr, temp_path, 1);
+              if (i != 0) {
+                fprintf(stderr, "\nwarning: couldn't revert the file to its original name\n");
+                fprintf(stderr, "original: "); fwprint(stderr, dupename->d_name, 1);
+                fprintf(stderr, "current:  "); fwprint(stderr, temp_path, 1);
+              }
             }
           }
         }

--- a/act_printmatches.c
+++ b/act_printmatches.c
@@ -11,6 +11,7 @@
 extern void printmatches(file_t * restrict files)
 {
   file_t * restrict tmpfile;
+  filename_t * restrict filename;
   int printed = 0;
 
   while (files != NULL) {
@@ -19,11 +20,13 @@ extern void printmatches(file_t * restrict files)
       if (!ISFLAG(flags, F_OMITFIRST)) {
         if (ISFLAG(flags, F_SHOWSIZE)) printf("%" PRIdMAX " byte%c each:\n", (intmax_t)files->size,
          (files->size != 1) ? 's' : ' ');
-        fwprint(stdout, files->filename->d_name, 1);
+        for (filename = files->filename; filename; filename = filename->next)
+          fwprint(stdout, filename->d_name, 1);
       }
       tmpfile = files->duplicates;
       while (tmpfile != NULL) {
-        fwprint(stdout, tmpfile->filename->d_name, 1);
+        for (filename = tmpfile->filename; filename; filename = filename->next)
+          fwprint(stdout, filename->d_name, 1);
         tmpfile = tmpfile->duplicates;
       }
       if (files->next != NULL) fwprint(stdout, "", 1);

--- a/act_printmatches.c
+++ b/act_printmatches.c
@@ -19,11 +19,11 @@ extern void printmatches(file_t * restrict files)
       if (!ISFLAG(flags, F_OMITFIRST)) {
         if (ISFLAG(flags, F_SHOWSIZE)) printf("%" PRIdMAX " byte%c each:\n", (intmax_t)files->size,
          (files->size != 1) ? 's' : ' ');
-        fwprint(stdout, files->d_name, 1);
+        fwprint(stdout, files->filename->d_name, 1);
       }
       tmpfile = files->duplicates;
       while (tmpfile != NULL) {
-        fwprint(stdout, tmpfile->d_name, 1);
+        fwprint(stdout, tmpfile->filename->d_name, 1);
         tmpfile = tmpfile->duplicates;
       }
       if (files->next != NULL) fwprint(stdout, "", 1);

--- a/jdupes.c
+++ b/jdupes.c
@@ -696,6 +696,7 @@ static void grokdir(const char * const restrict dir,
       newfilename->d_name = (char *)string_malloc(dirlen + d_name_len + 2);
       if (!newfilename->d_name) oom("grokdir() filename");
 
+      newfilename->file = newfile;
       newfilename->user_order = user_dir_count;
       
       newfile->filename = newfilename;
@@ -831,7 +832,6 @@ static void grokdir(const char * const restrict dir,
 #else
         if (S_ISREG(newfile->mode)) {
 #endif
-          *filelistp = newfile;
           filecount++;
           progress++;
 
@@ -843,15 +843,36 @@ static void grokdir(const char * const restrict dir,
 	  if (newfile->nlink > 1) {
 	    filerev = tsearch(newfile, &revtree, compare_revtree);
 	    if (!filerev) oom("grokdir() reverse lookup tree node");
-	    
+
 	    filerev = *(file_t **) filerev; /* get pointer from tree node */
 	    if (filerev == newfile) {
+	      /* a fresh device/inode pair */
 	      LOUD(fprintf(stderr, "new reverse lookup for %s\n", newfile->filename->d_name));
-	    } else {
+
+	      /* store file_t normally */
+	      *filelistp = newfile;
+	    }
+
+	    else {
+	      /* already known device/inode pair */
 	      LOUD(fprintf(stderr, "known reverse lookup from %s to %s\n", newfile->filename->d_name, filerev->filename->d_name));
+
+	      /* throw away new file_t */
+	      string_free(newfile);
+
+	      /* add filename to existing file_t */
+	      newfilename->next = filerev->filename;
+	      filerev->filename = newfilename;
+
+	      /* add reverse lookup from filename to file */
+	      newfilename->file = filerev;
 	    }
 	  } else {
 	    LOUD(fprintf(stderr, "skip reverse lookup, nlink < 2\n"));
+#endif /* NO_HARDLINKS */
+	    /* store file_t normally */
+	    *filelistp = newfile;
+#ifndef NO_HARDLINKS
 	  }
 #endif
 

--- a/jdupes.c
+++ b/jdupes.c
@@ -377,35 +377,35 @@ static int compare_revtree(const void * const node1, const void * const node2) {
 
 /* Check file's stat() info to make sure nothing has changed
  * Returns 1 if changed, 0 if not changed, negative if error */
-extern int file_has_changed(file_t * const restrict file)
+extern int file_has_changed(filename_t * const restrict filename)
 {
-  if (file == NULL || file->filename == NULL || file->filename->d_name == NULL) nullptr("file_has_changed()");
-  LOUD(fprintf(stderr, "file_has_changed('%s')\n", file->filename->d_name);)
+  if (filename == NULL || filename->file == NULL || filename->d_name == NULL) nullptr("file_has_changed()");
+  LOUD(fprintf(stderr, "file_has_changed('%s')\n", filename->d_name);)
 
-  if (!ISFLAG(file->flags, F_VALID_STAT)) return -66;
+  if (!ISFLAG(filename->file->flags, F_VALID_STAT)) return -66;
 
 #ifdef ON_WINDOWS
   int i;
-  if ((i = win_stat(file->filename->d_name, &ws)) != 0) return i;
-  if (file->inode != ws.inode) return 1;
-  if (file->size != ws.size) return 1;
-  if (file->device != ws.device) return 1;
-  if (file->mtime != ws.mtime) return 1;
-  if (file->mode != ws.mode) return 1;
+  if ((i = win_stat(filename->d_name, &ws)) != 0) return i;
+  if (filename->file->inode != ws.inode) return 1;
+  if (filename->file->size != ws.size) return 1;
+  if (filename->file->device != ws.device) return 1;
+  if (filename->file->mtime != ws.mtime) return 1;
+  if (filename->file->mode != ws.mode) return 1;
 #else
-  if (stat(file->filename->d_name, &s) != 0) return -2;
-  if (file->inode != s.st_ino) return 1;
-  if (file->size != s.st_size) return 1;
-  if (file->device != s.st_dev) return 1;
-  if (file->mtime != s.st_mtime) return 1;
-  if (file->mode != s.st_mode) return 1;
+  if (stat(filename->d_name, &s) != 0) return -2;
+  if (filename->file->inode != s.st_ino) return 1;
+  if (filename->file->size != s.st_size) return 1;
+  if (filename->file->device != s.st_dev) return 1;
+  if (filename->file->mtime != s.st_mtime) return 1;
+  if (filename->file->mode != s.st_mode) return 1;
  #ifndef NO_PERMS
-  if (file->uid != s.st_uid) return 1;
-  if (file->gid != s.st_gid) return 1;
+  if (filename->file->uid != s.st_uid) return 1;
+  if (filename->file->gid != s.st_gid) return 1;
  #endif
  #ifndef NO_SYMLINKS
-  if (lstat(file->filename->d_name, &s) != 0) return -3;
-  if ((S_ISLNK(s.st_mode) > 0) ^ ISFLAG(file->flags, F_IS_SYMLINK)) return 1;
+  if (lstat(filename->d_name, &s) != 0) return -3;
+  if ((S_ISLNK(s.st_mode) > 0) ^ ISFLAG(filename->file->flags, F_IS_SYMLINK)) return 1;
  #endif
 #endif /* ON_WINDOWS */
 

--- a/jdupes.c
+++ b/jdupes.c
@@ -422,6 +422,9 @@ extern inline int getfilestats(file_t * const restrict file)
   file->device = s.st_dev;
   file->mtime = s.st_mtime;
   file->mode = s.st_mode;
+ #ifndef NO_HARDLINKS
+  file->nlink = s.st_nlink;
+ #endif
  #ifndef NO_PERMS
   file->uid = s.st_uid;
   file->gid = s.st_gid;
@@ -678,10 +681,8 @@ static void grokdir(const char * const restrict dir,
       newfile->inode = 0;
       newfile->mtime = 0;
       newfile->mode = 0;
-#ifdef ON_WINDOWS
- #ifndef NO_HARDLINKS
+#ifndef NO_HARDLINKS
       newfile->nlink = 0;
- #endif
 #endif
 #ifndef NO_PERMS
       newfile->uid = 0;

--- a/jdupes.h
+++ b/jdupes.h
@@ -170,6 +170,8 @@ typedef enum {
 
 /* Per-file information unique to a filename */
 typedef struct _filename {
+  struct _filename *next;
+  struct _file *file;
   char *d_name;
   unsigned int user_order; /* Order of the originating command-line parameter */
 } filename_t;

--- a/jdupes.h
+++ b/jdupes.h
@@ -168,11 +168,17 @@ typedef enum {
 /* For interactive deletion input */
 #define INPUT_SIZE 512
 
-/* Per-file information */
+/* Per-file information unique to a filename */
+typedef struct _filename {
+  char *d_name;
+  unsigned int user_order; /* Order of the originating command-line parameter */
+} filename_t;
+
+/* Per-file information unique to an inode */
 typedef struct _file {
   struct _file *duplicates;
   struct _file *next;
-  char *d_name;
+  filename_t *filename;
   dev_t device;
   jdupes_mode_t mode;
   off_t size;
@@ -181,7 +187,6 @@ typedef struct _file {
   hash_t filehash;
   time_t mtime;
   uint32_t flags;  /* Status flags */
-  unsigned int user_order; /* Order of the originating command-line parameter */
 #ifndef NO_PERMS
   uid_t uid;
   gid_t gid;
@@ -218,7 +223,7 @@ extern void nullptr(const char * restrict func);
 extern int file_has_changed(file_t * const restrict file);
 extern int getfilestats(file_t * const restrict file);
 extern int getdirstats(const char * const restrict name,
-        jdupes_ino_t * const restrict inode, dev_t * const restrict dev);
+        jdupes_ino_t * const restrict file, dev_t * const restrict dev);
 extern int check_conditions(const file_t * const restrict file1, const file_t * const restrict file2);
 extern unsigned int get_max_dupes(const file_t *files, unsigned int * const restrict max,
 		                unsigned int * const restrict n_files);

--- a/jdupes.h
+++ b/jdupes.h
@@ -168,6 +168,8 @@ typedef enum {
 /* For interactive deletion input */
 #define INPUT_SIZE 512
 
+struct _file; /* prototype */
+
 /* Per-file information unique to a filename */
 typedef struct _filename {
   struct _filename *next;
@@ -222,7 +224,7 @@ extern struct stat s;
 
 extern void oom(const char * const restrict msg);
 extern void nullptr(const char * restrict func);
-extern int file_has_changed(file_t * const restrict file);
+extern int file_has_changed(filename_t * const restrict filename);
 extern int getfilestats(file_t * const restrict file);
 extern int getdirstats(const char * const restrict name,
         jdupes_ino_t * const restrict file, dev_t * const restrict dev);

--- a/jdupes.h
+++ b/jdupes.h
@@ -186,9 +186,11 @@ typedef struct _file {
   uid_t uid;
   gid_t gid;
 #endif
-#ifdef ON_WINDOWS
- #ifndef NO_HARDLINKS
+#ifndef NO_HARDLINKS
+ #ifdef ON_WINDOWS
   DWORD nlink;
+ #else
+  nlink_t nlink;
  #endif
 #endif
 } file_t;

--- a/win_stat.c
+++ b/win_stat.c
@@ -46,7 +46,7 @@ int win_stat(const char * const filename, struct winstat * const restrict buf)
   if (hFile == INVALID_HANDLE_VALUE) goto failure;
   if (!GetFileInformationByHandle(hFile, &bhfi)) goto failure2;
 
-  buf->inode = ((uint64_t)(bhfi.nFileIndexHigh) << 32) + (uint64_t)bhfi.nFileIndexLow;
+  buf->file = ((uint64_t)(bhfi.nFileIndexHigh) << 32) + (uint64_t)bhfi.nFileIndexLow;
   buf->size = ((uint64_t)(bhfi.nFileSizeHigh) << 32) + (uint64_t)bhfi.nFileSizeLow;
   timetemp = ((uint64_t)(bhfi.ftCreationTime.dwHighDateTime) << 32) + bhfi.ftCreationTime.dwLowDateTime;
   buf->ctime = nttime_to_unixtime(&timetemp);

--- a/win_stat.h
+++ b/win_stat.h
@@ -15,7 +15,7 @@ extern "C" {
 #include <windows.h>
 
 struct winstat {
-	uint64_t inode;
+	uint64_t file;
 	int64_t size;
 	uint32_t device;
 	uint32_t nlink;


### PR DESCRIPTION
I've fiddled around with jdupes and made a pretty big changeset… I decided to present it as a set of commits to make it easier to understand what is going on.  Also after rereading issue #26 I am now convinced that this really has nothing to do with the triangle problem ;-)

The basic idea is to group all hardlinked scanned files. To achieve this, the old `file_t` structure has been split into `file_t` (which represents the group part, eg. an inode) and `filename_t` (which represents filename (which points to an inode)). Every `filename_t` points to a single `file_t`, but a `file_t` can be shared by and point to multiple `filename_t`.

The phase of comparing the scanned files works like before.

The actions have been changed to match the `file_t`/`filename_t` change.

### benefits / what is working

* Multiple filenames pointing to the same inode on the same device (aka hardlink groups) are detected automatically.
* Fewer file comparisons when hardlink groups are present as the inode (aka the file content) is only read once instead of once per filename.
* Less memory usage when many hardlink groups are present as fewer `file_t` need to be allocated (somewhat counteracted by additional memory usage of the reverse inode lookup tree, the new `nlink` field in `file_t` under non-Windows and the additional pointers from `file_t` to `filename_t` and back).
* Detecting the hardlink groups fixes issue #43 without any further changes to the summarize action.
* Storing of the hardlink count for every file is a first step to implement issue #42.

### downsides / what is not working

* The actions _dedupe (btrfs)_ and _delete_ have not yet been ported to the new `file_t`/`filename_t` construct. They currently print an error to cause no harm. I see no special problems with these actions, it is just a time and effort issue. Also, I don't have any btrfs filesystems.
* Memory usage per file is slightly higher because of additional pointers between `file_t` and `filename_t` as well as the new field `nlink` in `file_t` under non-Windows. (When a file only has 1 link, the file is /not/ added to the reverse inode lookup tree, so at least there is no unneeded memory overhead for the tree.)

### conclusion

So basically despite being so big of a change this directly fixes only issue #43.
But I think it is a step into the right direction because the new `file_t`/`filename_t` relationship better resembles the relationship between inodes and filenames in a filesystem and thus will come in handy in other cases, too.

I have some further comments/questions to both the changed code and the original code. I will try to add them as direct comments to the commits/code (have not tried this with Github yet).