### PR TITLE
--linkhard: success flag is neither initialized nor reset under Windows

### DIFF
--- a/act_linkfiles.c
+++ b/act_linkfiles.c
@@ -212,6 +212,7 @@ extern void linkfiles(file_t *files, const int hard)
 
         /* Create the desired hard link with the original file's name */
         errno = 0;
+        success = 0;
 #ifdef ON_WINDOWS
  #ifdef UNICODE
         if (!M2W(srcfile->d_name, wname2)) {
@@ -223,7 +224,6 @@ extern void linkfiles(file_t *files, const int hard)
         if (CreateHardLink(dupelist[x]->d_name, srcfile->d_name, NULL) == TRUE) success = 1;
  #endif
 #else
-        success = 0;
         if (hard) {
           if (link(srcfile->d_name, dupelist[x]->d_name) == 0) success = 1;
  #ifdef NO_SYMLINKS


### PR DESCRIPTION
This looks like a bug to me:

Under Windows, `success` has no initial value and once it is set to `1`, it will never change again for the loop duration. If the initial value by chance is `1`, errors during linking will not be detected or printed.

It also looks like when there are multiple dupes for a file and the first link was successful, any later errors in that file group will be not be shown as errors but as successful links.