### PR TITLE
Added option to detect duplicates against a directory containing originals

### DIFF
--- a/act_deletefiles.c
+++ b/act_deletefiles.c
@@ -46,18 +46,24 @@ extern void deletefiles(file_t *files, int prompt, FILE *tty)
       tmpfile = files->duplicates;
 
       while (tmpfile) {
-        dupelist[++counter] = tmpfile;
-        if (prompt) {
-          printf("[%u] ", counter); fwprint(stdout, tmpfile->d_name, 1);
+        if (ISFLAG(tmpfile->flags, F_IS_ORIGINAL)) {
+          if (prompt) {
+            printf("[ORIGINAL] "); fwprint(stdout, tmpfile->d_name, 1);
+          }
+        } else {
+          dupelist[++counter] = tmpfile;
+          if (prompt) {
+            printf("[%u] ", counter); fwprint(stdout, tmpfile->d_name, 1);
+          }
         }
         tmpfile = tmpfile->duplicates;
       }
 
       if (prompt) printf("\n");
 
-      /* preserve only the first file */
       if (!prompt) {
-        preserve[1] = 1;
+        /* preserve only the first file, unless using originals as preserved files. */
+        preserve[1] = !ISFLAG(flags, F_ORIGINALS);
         for (x = 2; x <= counter; x++) preserve[x] = 0;
       } else do {
         /* prompt for files to preserve */

--- a/act_printmatches.c
+++ b/act_printmatches.c
@@ -23,6 +23,7 @@ extern void printmatches(file_t * restrict files)
       }
       tmpfile = files->duplicates;
       while (tmpfile != NULL) {
+        if (ISFLAG(tmpfile->flags, F_IS_ORIGINAL)) printf("[ORIGINAL] ");
         fwprint(stdout, tmpfile->d_name, 1);
         tmpfile = tmpfile->duplicates;
       }

--- a/jdupes.c
+++ b/jdupes.c
@@ -1206,7 +1206,7 @@ static inline void rebalance_tree(filetree_t * const tree)
 
 
 /* Check two files for a match */
-static file_t **checkmatch(filetree_t * restrict tree, file_t * const restrict file, int do_register)
+static file_t **checkmatch(filetree_t * restrict tree, file_t * const restrict file)
 {
   int cmpresult = 0;
   const hash_t * restrict filehash;
@@ -1304,8 +1304,8 @@ static file_t **checkmatch(filetree_t * restrict tree, file_t * const restrict f
     if (tree->left != NULL) {
       LOUD(fprintf(stderr, "checkmatch: recursing tree: left\n"));
       DBG(left_branch++; tree_depth++;)
-      return checkmatch(tree->left, file, do_register);
-    } else if (do_register) {
+      return checkmatch(tree->left, file);
+    } else if (!ISFLAG(flags, F_ORIGINALS) || ISFLAG(file->flags, F_IS_ORIGINAL))  {
       LOUD(fprintf(stderr, "checkmatch: registering file: left\n"));
       registerfile(&tree, LEFT, file);
       TREE_DEPTH_UPDATE_MAX();
@@ -1318,8 +1318,8 @@ static file_t **checkmatch(filetree_t * restrict tree, file_t * const restrict f
     if (tree->right != NULL) {
       LOUD(fprintf(stderr, "checkmatch: recursing tree: right\n"));
       DBG(right_branch++; tree_depth++;)
-      return checkmatch(tree->right, file, do_register);
-    } else if (do_register) {
+      return checkmatch(tree->right, file);
+    } else if (!ISFLAG(flags, F_ORIGINALS) || ISFLAG(file->flags, F_IS_ORIGINAL)) {
       LOUD(fprintf(stderr, "checkmatch: registering file: right\n"));
       registerfile(&tree, RIGHT, file);
       TREE_DEPTH_UPDATE_MAX();
@@ -1937,7 +1937,7 @@ int main(int argc, char **argv)
     while (original) {
       SETFLAG(original->flags, F_IS_ORIGINAL);
       if (!checktree) registerfile(&checktree, NONE, original);
-      else checkmatch(checktree, original, 1);
+      else checkmatch(checktree, original);
       original = original->next;
       progress++;
     }
@@ -1973,9 +1973,9 @@ int main(int argc, char **argv)
     LOUD(fprintf(stderr, "\nMAIN: current file: %s\n", curfile->d_name));
 
     if (ISFLAG(flags, F_ORIGINALS)) {
-      if (checktree) match = checkmatch(checktree, curfile, 0);
+      if (checktree) match = checkmatch(checktree, curfile);
     } else if (!checktree) registerfile(&checktree, NONE, curfile);
-    else match = checkmatch(checktree, curfile, 1);
+    else match = checkmatch(checktree, curfile);
 
 #ifdef USE_TREE_REBALANCE
     /* Rebalance the match tree after a certain number of files processed */

--- a/jdupes.h
+++ b/jdupes.h
@@ -135,6 +135,7 @@ extern uint_fast32_t flags;
 #define F_MAKESYMLINKS		0x00200000U
 #define F_PRINTMATCHES		0x00400000U
 #define F_ONEFS			0x00800000U
+#define F_ORIGINALS			0x01000000U
 
 #define F_LOUD			0x40000000U
 #define F_DEBUG			0x80000000U
@@ -145,6 +146,7 @@ extern uint_fast32_t flags;
 #define F_HASH_FULL		0x00000004U
 #define F_HAS_DUPES		0x00000008U
 #define F_IS_SYMLINK		0x00000010U
+#define F_IS_ORIGINAL   0x00000020U
 
 typedef enum {
   ORDER_NAME = 0,


### PR DESCRIPTION
A common case for files duplicates is when the files are in a primary location (i.e. **originals**), but some of them also appears in other directories (i.e. **working files**). The ideal workflow for removing the duplicates in this case is to check working files against originals and remove only working files.

The proposed change adds a new option, **-g** or **--originals**, which specifies the "originals" files. When --originals directory is specified, the checktree is updated only with the originals and working files are only checked against originals in checktree, but not registered in the tree. In other words, when --originals are specified, working files are not checked among themselves, only against originals.

The deletion preserves the originals, with the same caveat that overlapping directories or symlinks may result in originals being removed.

If the feature looks interesting for jdupes, please take a look at the pull request. The change probably requires more work, because I'm not fluent in C and not very familiar with the overall design of the program. Please take it as a proof of concept and suggest how it should evolve.

Thank you,
Razvan