### PR TITLE
2 commits about collision handling

### DIFF
--- a/jdupes.h
+++ b/jdupes.h
@@ -51,6 +51,7 @@ extern "C" {
  #define JODY_HASH_NOCOMPAT
  #include "jody_hash.h"
 #elif defined USE_HASH_XXHASH64
+ #define XXH_STATIC_LINKING_ONLY   /* *_state_t */
  #include "xxhash.h"
 #endif
 

--- a/testdir/collision/duplicates/A.txt
+++ b/testdir/collision/duplicates/A.txt
@@ -1,0 +1,1 @@
+ncAOkNPzUv2LcPbl

--- a/testdir/collision/duplicates/B.txt
+++ b/testdir/collision/duplicates/B.txt
@@ -1,0 +1,1 @@
+ncAOkNSzUF2LcPbl

--- a/testdir/collision/duplicates/C.txt
+++ b/testdir/collision/duplicates/C.txt
@@ -1,0 +1,1 @@
+ncAOkNRzUV2LcPbl

--- a/testdir/collision/duplicates/D.txt
+++ b/testdir/collision/duplicates/D.txt
@@ -1,0 +1,1 @@
+ncAOkNQzUf2LcPbl

--- a/testdir/collision/identical/jcoll (1).txt
+++ b/testdir/collision/identical/jcoll (1).txt
@@ -1,0 +1,1 @@
+ncAOkNPzUv2LcPbl

--- a/testdir/collision/identical/jcoll (2).txt
+++ b/testdir/collision/identical/jcoll (2).txt
@@ -1,0 +1,1 @@
+ncAOkNSzUF2LcPbl

--- a/testdir/collision/identical/jcoll (3).txt
+++ b/testdir/collision/identical/jcoll (3).txt
@@ -1,0 +1,1 @@
+ncAOkNRzUV2LcPbl

--- a/testdir/collision/identical/jcoll (4).txt
+++ b/testdir/collision/identical/jcoll (4).txt
@@ -1,0 +1,1 @@
+ncAOkNQzUf2LcPbl


### PR DESCRIPTION
jdupes is serious by doing a time consuming byte-by-byte comparision after full hash compares equal, but I find a case when collision do happen it would not work correctly, with or without -Q

details in commit message
sample also included in testdir

first commit improve xxHash64 call, in case somebody take this as workaround
second commit is my ugly fix handling hash collision. I basically move confirm_match() logic from main() into checkmatch()

This is just my solution to this case, Please take it as a proof of concept and suggest how it should evolve.

Thank you,
Asureus
 