### PR TITLE
improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,9 @@ OBJS += jody_cacheinfo.o
 OBJS += act_deletefiles.o act_linkfiles.o act_printmatches.o act_summarize.o
 OBJS += $(ADDITIONAL_OBJECTS)
 
-all: jdupes
+all: $(PROGRAM_NAME)
 
-jdupes: $(OBJS)
+$(PROGRAM_NAME): $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(PROGRAM_NAME) $(OBJS)
 
 installdirs:


### PR DESCRIPTION
If PROGRAM_NAME is changed, or build on Windows (target is jdupes.exe), GNU make keeps re-linking even if nothing changes.
