### PR TITLE
Use `/usr/local` as the default install prefix in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 # PREFIX determines where files will be installed. Common examples
 # include "/usr" or "/usr/local".
-PREFIX = /usr
+PREFIX = /usr/local
 
 # Certain platforms do not support long options (command line options).
 # To disable long options, uncomment the following line.


### PR DESCRIPTION
This follows the convention used in most other Makefiles and CMake projects. It makes sure distribution-supplied files aren't affected when installing or uninstalling jdupes using `make`.