### PR TITLE
fix issue 77: isolate option, etc., prevent some matches being found

### DIFF
--- a/jdupes-standalone.c
+++ b/jdupes-standalone.c
@@ -636,18 +636,25 @@ static int getdirstats(const char * const restrict name,
  *  0 if all condition checks pass
  * -1 or 1 on compare result less/more
  * -2 on an absolute exclusion condition met
- *  2 on an absolute match condition met */
+ *  2 on an absolute match condition met
+ * -3 on exclusion due to isolation
+ * -4 on exlusion due to same filesystem
+ * -5 on exclusion due to permissions */
 static int check_conditions(const file_t * const restrict file1, const file_t * const restrict file2)
 {
   if (file1 == NULL || file2 == NULL || file1->d_name == NULL || file2->d_name == NULL) nullptr("check_conditions()");
 
+  /* Exclude files that are not the same size */
+  if (file1->size > file2->size) return -1;
+  if (file1->size < file2->size) return 1;
+
 #ifndef NO_USER_ORDER
   /* Exclude based on -I/--isolate */
-  if (ISFLAG(flags, F_ISOLATE) && (file1->user_order == file2->user_order)) return -1;
+  if (ISFLAG(flags, F_ISOLATE) && (file1->user_order == file2->user_order)) return -3;
 #endif /* NO_USER_ORDER */
 
   /* Exclude based on -1/--one-file-system */
-  if (ISFLAG(flags, F_ONEFS) && (file1->device != file2->device)) return -1;
+  if (ISFLAG(flags, F_ONEFS) && (file1->device != file2->device)) return -4;
 
    /* Exclude files by permissions if requested */
   if (ISFLAG(flags, F_PERMISSIONS) &&
@@ -657,7 +664,7 @@ static int check_conditions(const file_t * const restrict file1, const file_t * 
           || file1->gid != file2->gid
 #endif
           )) {
-    return -1;
+    return -5;
   }
 
   /* Hard link and symlink + '-s' check */
@@ -667,10 +674,6 @@ static int check_conditions(const file_t * const restrict file1, const file_t * 
     else return -2;
   }
 #endif
-
-  /* Exclude files that are not the same size */
-  if (file1->size > file2->size) return -1;
-  if (file1->size < file2->size) return 1;
 
   /* Fall through: all checks passed */
   return 0;
@@ -1766,6 +1769,7 @@ static void registerfile(filetree_t * restrict * const restrict nodeptr,
 static file_t **checkmatch(filetree_t * restrict tree, file_t * const restrict file)
 {
   int cmpresult = 0;
+  int cantmatch = 0;
   const jdupes_hash_t * restrict filehash;
 
   if (tree == NULL || file == NULL || tree->file == NULL || tree->file->d_name == NULL || file->d_name == NULL) nullptr("checkmatch()");
@@ -1784,6 +1788,12 @@ static file_t **checkmatch(filetree_t * restrict tree, file_t * const restrict f
   switch (cmpresult) {
     case 2: return &tree->file;  /* linked files + -H switch */
     case -2: return NULL;  /* linked files, no -H switch */
+    case -3:    /* user order */
+    case -4:    /* one filesystem */
+    case -5:    /* permissions */
+        cantmatch = 1;
+        cmpresult = 0;
+        break;
     default: break;
   }
 
@@ -1846,6 +1856,10 @@ static file_t **checkmatch(filetree_t * restrict tree, file_t * const restrict f
       /* Full file hash comparison */
       cmpresult = HASH_COMPARE(file->filehash, tree->file->filehash);
     }
+  }
+
+  if( (cantmatch!=0) && (cmpresult==0) ) {
+    cmpresult = -1;
   }
 
   if (cmpresult < 0) {

--- a/jdupes.c
+++ b/jdupes.c
@@ -583,7 +583,10 @@ extern int getdirstats(const char * const restrict name,
  *  0 if all condition checks pass
  * -1 or 1 on compare result less/more
  * -2 on an absolute exclusion condition met
- *  2 on an absolute match condition met */
+ *  2 on an absolute match condition met
+ * -3 on exclusion due to isolation
+ * -4 on exlusion due to same filesystem
+ * -5 on exclusion due to permissions */
 extern int check_conditions(const file_t * const restrict file1, const file_t * const restrict file2)
 {
   if (file1 == NULL || file2 == NULL || file1->d_name == NULL || file2->d_name == NULL) nullptr("check_conditions()");


### PR DESCRIPTION
tree search fails to find some candidate matches due to hash combined with isolate or permissions  descending wrong branch. Properly check size first, then indicate reason for why match can't be allowed, and properly handle adding to tree.  This will cause additional comparison (front/back of file, ...) to be performed, even if file can't be matched due to isolation, etc. - more efficient fix is to have separate trees for each search directory when using isolate.