### PR TITLE
Genericize BTRFS dedup to FIDEDUPERANGE

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -28,7 +28,7 @@ instead of using CFLAGS_EXTRA, i.e. 'make DEBUG=1':
 
 DEBUG                  Turn on algorithm statistic reporting with '-D'
 LOUD                   '-@' for low-level debugging; enables DEBUG
-ENABLE_BTRFS           Enable '-B/--dedupe' for btrfs deduplication
+ENABLE_FSDEDUP         Enable '-B/--dedupe' for filesystem deduplication
 STATIC_BTRFS_H         Build BTRFS support with included minimal header file
 LOW_MEMORY             Build for lower memory usage instead of speed
 NO_PERMS               Disable permission options and code

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ PREFIX = /usr/local
 # To disable long options, uncomment the following line.
 #CFLAGS += -DOMIT_GETOPT_LONG
 
-# Uncomment for Linux with BTRFS support. Needed for -B/--dedupe.
-# This can also be enabled at build time: 'make ENABLE_BTRFS=1'
-#CFLAGS += -DENABLE_BTRFS
+# Uncomment for Linux for -B/--dedupe.
+# This can also be enabled at build time: 'make ENABLE_FSDEDUP=1'
+#CFLAGS += -DENABLE_FSDEDUP
 
 # Uncomment for low memory usage at the expense of speed and features
 # This can be enabled at build time: 'make LOW_MEMORY=1'
@@ -80,12 +80,12 @@ ifdef HARDEN
 COMPILER_OPTIONS += -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE -fpie -Wl,-z,relro -Wl,-z,now
 endif
 
-# Catch someone trying to enable BTRFS in flags and turn on ENABLE_BTRFS
-ifneq (,$(findstring DENABLE_BTRFS,$(CFLAGS)))
-	ENABLE_BTRFS=1
+# Catch someone trying to enable BTRFS in flags and turn on ENABLE_FSDEDUP
+ifneq (,$(findstring DENABLE_BTRFS,$(CFLAGS) $(CFLAGS_EXTRA)))
+	ENABLE_FSDEDUP=1
 endif
-ifneq (,$(findstring DENABLE_BTRFS,$(CFLAGS_EXTRA)))
-	ENABLE_BTRFS=1
+ifneq (,$(findstring DENABLE_FSDEDUP,$(CFLAGS) $(CFLAGS_EXTRA)))
+	ENABLE_FSDEDUP=1
 endif
 
 # MinGW needs this for printf() conversions to work
@@ -97,12 +97,15 @@ ifndef NO_UNICODE
 endif
 	COMPILER_OPTIONS += -D__USE_MINGW_ANSI_STDIO=1 -DON_WINDOWS=1
 	OBJS += win_stat.o winres.o
-	override undefine ENABLE_BTRFS
+	override undefine ENABLE_FSDEDUP
 endif
 
 # New BTRFS support option
 ifdef ENABLE_BTRFS
-COMPILER_OPTIONS += -DENABLE_BTRFS
+ENABLE_FSDEDUP=1
+endif
+ifdef ENABLE_FSDEDUP
+COMPILER_OPTIONS += -DENABLE_FSDEDUP
 OBJS += act_dedupefiles.o
 else
 OBJS_CLEAN += act_dedupefiles.o

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ option is specified (delete, summarize, link, dedupe, etc.)
  -0 --printnull         output nulls instead of CR/LF (like 'find -print0')
  -1 --one-file-system   do not match files on different filesystems/devices
  -A --nohidden          exclude hidden files from consideration
- -B --dedupe            Send matches to btrfs for block-level deduplication
+ -B --dedupe            Send matches to filesystem for block-level deduplication
  -C --chunksize=#       override I/O chunk size (min 4096, max 16777216)
  -d --delete            prompt user for files to preserve and delete all
                         others; important: under particular circumstances,

--- a/btrfs-static.h
+++ b/btrfs-static.h
@@ -25,9 +25,9 @@
 
 #define BTRFS_DEVICE_PATH_NAME_MAX 1024
 
-#define BTRFS_SAME_DATA_DIFFERS	1
+#define FILE_DEDUPE_RANGE_DIFFERS	1
 /* For extent-same ioctl */
-struct btrfs_ioctl_same_extent_info {
+struct file_dedupe_range_info {
 	__s64 fd;		/* in - destination file */
 	__u64 logical_offset;	/* in - start of extent in destination */
 	__u64 bytes_deduped;	/* out - total # of bytes we were able
@@ -35,22 +35,22 @@ struct btrfs_ioctl_same_extent_info {
 	/* status of this dedupe operation:
 	 * 0 if dedup succeeds
 	 * < 0 for error
-	 * == BTRFS_SAME_DATA_DIFFERS if data differs
+	 * == FILE_DEDUPE_RANGE_DIFFERS if data differs
 	 */
 	__s32 status;		/* out - see above description */
 	__u32 reserved;
 };
 
-struct btrfs_ioctl_same_args {
+struct file_dedupe_range {
 	__u64 logical_offset;	/* in - start of extent in source */
 	__u64 length;		/* in - length of extent */
 	__u16 dest_count;	/* in - total elements in info array */
 	__u16 reserved1;
 	__u32 reserved2;
-	struct btrfs_ioctl_same_extent_info info[0];
+	struct file_dedupe_range_info info[0];
 };
 
-#define BTRFS_IOC_FILE_EXTENT_SAME _IOWR(BTRFS_IOCTL_MAGIC, 54, \
-					 struct btrfs_ioctl_same_args)
+#define FIDEDUPERANGE _IOWR(BTRFS_IOCTL_MAGIC, 54, \
+					 struct file_dedupe_range)
 
 #endif /* JDUPES_BTRFS_H */

--- a/jdupes.c
+++ b/jdupes.c
@@ -168,8 +168,8 @@ const char *extensions[] = {
     #ifdef LOUD_DEBUG
     "loud",
     #endif
-    #ifdef ENABLE_BTRFS
-    "btrfs",
+    #ifdef ENABLE_FSDEDUP
+    "fsdedup",
     #endif
     #ifdef LOW_MEMORY
     "lowmem",
@@ -1495,8 +1495,8 @@ static inline void help_text(void)
   printf(" -0 --printnull   \toutput nulls instead of CR/LF (like 'find -print0')\n");
   printf(" -1 --one-file-system \tdo not match files on different filesystems/devices\n");
   printf(" -A --nohidden    \texclude hidden files from consideration\n");
-#ifdef ENABLE_BTRFS
-  printf(" -B --dedupe      \tsend matches to btrfs for block-level deduplication\n");
+#ifdef ENABLE_FSDEDUP
+  printf(" -B --dedupe      \tsend matches to filesystem for block-level deduplication\n");
 #endif
   printf(" -C --chunksize=# \toverride I/O chunk size (min %d, max %d)\n", MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
   printf(" -d --delete      \tprompt user for files to preserve and delete all\n");
@@ -1900,7 +1900,7 @@ int main(int argc, char **argv)
       }
       break;
     case 'B':
-#ifdef ENABLE_BTRFS
+#ifdef ENABLE_FSDEDUP
       SETFLAG(flags, F_DEDUPEFILES);
       /* btrfs will do the byte-for-byte check itself */
       SETFLAG(flags, F_QUICKCOMPARE);
@@ -1950,7 +1950,7 @@ int main(int argc, char **argv)
     exit(EXIT_FAILURE);
   }
 
-#ifdef ENABLE_BTRFS
+#ifdef ENABLE_FSDEDUP
   if (ISFLAG(flags, F_CONSIDERHARDLINKS) && ISFLAG(flags, F_DEDUPEFILES))
     fprintf(stderr, "warning: option --dedupe overrides the behavior of --hardlinks\n");
 #endif
@@ -2118,9 +2118,9 @@ skip_file_scan:
 #ifndef NO_HARDLINKS
   if (ISFLAG(flags, F_HARDLINKFILES)) linkfiles(files, 1);
 #endif /* NO_HARDLINKS */
-#ifdef ENABLE_BTRFS
+#ifdef ENABLE_FSDEDUP
   if (ISFLAG(flags, F_DEDUPEFILES)) dedupefiles(files);
-#endif /* ENABLE_BTRFS */
+#endif /* ENABLE_FSDEDUP */
   if (ISFLAG(flags, F_PRINTMATCHES)) printmatches(files);
   if (ISFLAG(flags, F_PRINTJSON)) printjson(files, argc, argv);
   if (ISFLAG(flags, F_SUMMARIZEMATCHES)) {


### PR DESCRIPTION
Linux kernel since 4.5 has renamed the identifier to FIDEDUPERANGE and
moved it out of the btrfs-specific space. We should expect to see more
filesystems support it.

Dedup on Windows and MacOS will be very different: although both
systems have deduplicating filesystems, there is no simple API that
does the comparison for us. Instead there is clonefile(2) on masOS
that resembles a whole-file copy (with all the permission issues that
come with it) or hardlink and FSCTL_DUPLICATE_EXTENTS_TO_FILE_EX on
Windows that needs our own block chunking and handling. [The Windows
headers vaguely suggest an undocumented FSCTL_DEDUP_FILE that may or
may not do it for us.]