### PR TITLE
fix json printout for any utf-8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ COMPILER_OPTIONS += -DLOUD_DEBUG
 endif
 ifdef DEBUG
 COMPILER_OPTIONS += -DDEBUG
+else
+COMPILER_OPTIONS += -DNDEBUG
 endif
 ifdef HARDEN
 COMPILER_OPTIONS += -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE -fpie -Wl,-z,relro -Wl,-z,now


### PR DESCRIPTION
The existing implementation did not consider anything about UTF-8, which is what we are using here on Windows and usually on Linux. Let's fix that.