### PR TITLE
Define PATH_MAX variable to fix a FTBFS in Hurd

### DIFF
--- a/act_printjson.c
+++ b/act_printjson.c
@@ -21,6 +21,10 @@
 #define likely(x)   __builtin_expect((x),1)
 #define unlikely(x) __builtin_expect((x),0)
 
+#if defined(__GNU__) && !defined(PATH_MAX)
+#define PATH_MAX 1024
+#endif
+
 /** Decodes a single UTF-8 codepoint, consuming bytes. */
 static inline uint32_t decode_utf8(const char * restrict * const string) {
   uint32_t ret = 0;


### PR DESCRIPTION
  It will fix a Fail To Build From Source:
  act_printjson.c:110:30: error: 'PATH_MAX' undeclared (first use in this function)

  When building in Debian Hurd, the system shows:
    act_printjson.c: In function ‘printjson’:
    act_printjson.c:110:30: error: ‘PATH_MAX’ undeclared (first use in this function)
      110 |   char *temp = string_malloc(PATH_MAX * 2);
          |                              ^~~~~~~~
    <builtin>: recipe for target 'act_printjson.o' failed
    make[2]: *** [act_printjson.o] Error 1