### PR TITLE
Hard link count limit and work around for stack overflow error

### DIFF
--- a/act_linkfiles.c
+++ b/act_linkfiles.c
@@ -165,27 +165,25 @@ extern void linkfiles(file_t *files, const int hard)
           fwprint(stderr, dupelist[x]->d_name, 1);
           continue;
         }
-#ifdef ON_WINDOWS
-        /* For Windows, the hard link count maximum is 1023 (+1); work around
-         * by skipping linking or changing the link source file as needed */
+        /* For Windows, the hard link count maximum is 1023 (+1); On Linux/ext4 file system the hard link count maximum is 65000;
+           work around by skipping linking or changing the link source file as needed */
         if (STAT(srcfile->d_name, &s) != 0) {
-          fprintf(stderr, "warning: win_stat() on source file failed, changing source file:\n[SRC] ");
+          fprintf(stderr, "warning: stat() on source file failed, changing source file:\n[SRC] ");
           fwprint(stderr, dupelist[x]->d_name, 1);
           srcfile = dupelist[x];
           continue;
         }
-        if (s.st_nlink >= 1024) {
+        if (s.st_nlink >= MAX_HARDLINK_COUNT) {
           fprintf(stderr, "warning: maximum source link count reached, changing source file:\n[SRC] ");
           srcfile = dupelist[x];
           continue;
         }
         if (STAT(dupelist[x]->d_name, &s) != 0) continue;
-        if (s.st_nlink >= 1024) {
+        if (s.st_nlink >= MAX_HARDLINK_COUNT) {
           fprintf(stderr, "warning: maximum destination link count reached, skipping:\n-//-> ");
           fwprint(stderr, dupelist[x]->d_name, 1);
           continue;
         }
-#endif
 
         /* Make sure the name will fit in the buffer before trying */
         name_len = strlen(dupelist[x]->d_name) + 14;

--- a/jdupes.c
+++ b/jdupes.c
@@ -673,19 +673,18 @@ static int check_singlefile(file_t * const restrict newfile)
     }
   }
 
-#ifdef ON_WINDOWS
-  /* Windows has a 1023 (+1) hard link limit. If we're hard linking,
-   * ignore all files that have hit this limit */
+  /* Windows has a 1023 (+1) hard link limit. On linux/ext4 it is 65000; 
+   * If we're hard linking, ignore all files that have hit this limit */
  #ifndef NO_HARDLINKS
-  if (ISFLAG(flags, F_HARDLINKFILES) && newfile->nlink >= 1024) {
+  if (ISFLAG(flags, F_HARDLINKFILES) && newfile->nlink >= MAX_HARDLINK_COUNT) {
   #ifdef DEBUG
     hll_exclude++;
   #endif
-    LOUD(fprintf(stderr, "check_singlefile: excluding due to Windows 1024 hard link limit\n"));
+    LOUD(fprintf(stderr, "check_singlefile: excluding due to %i hard link limit\n", MAX_HARDLINK_COUNT));
     return 1;
   }
  #endif /* NO_HARDLINKS */
-#endif /* ON_WINDOWS */
+
   return 0;
 }
 
@@ -1507,7 +1506,9 @@ static inline void help_text(void)
 #ifndef NO_HARDLINKS
   printf(" -L --linkhard    \thard link all duplicate files without prompting\n");
  #ifdef ON_WINDOWS
-  printf("                  \tWindows allows a maximum of 1023 hard links per file\n");
+  printf("                  \tWindows allows a maximum of %i hard links per file\n", MAX_HARDLINK_COUNT);
+#else
+  printf("                  \t(max number hard links per file: %i)\n", MAX_HARDLINK_COUNT);
  #endif /* ON_WINDOWS */
 #endif /* NO_HARDLINKS */
   printf(" -m --summarize   \tsummarize dupe information\n");

--- a/jdupes.h
+++ b/jdupes.h
@@ -16,12 +16,17 @@ extern "C" {
  #define NO_SYMLINKS 1
  #define NO_PERMS 1
  #define NO_SIGACTION 1
+ #define MAX_HARDLINK_COUNT 1023 
  #ifndef WIN32_LEAN_AND_MEAN
   #define WIN32_LEAN_AND_MEAN
  #endif
  #include <windows.h>
  #include <io.h>
  #include "win_stat.h"
+#else
+  /* this is the maximum number of hardlinks per file on ext4. For other file systems this can be relaxed. 
+     Would need a specific configuration option or probing at the beginning */
+ #define MAX_HARDLINK_COUNT 65000 
 #endif /* Win32 */
 
 #include <limits.h>


### PR DESCRIPTION
I had used jdupes on a large directory tree and encountered two problems that I fixed in this PR:

a) On ext4 file systems the hard link count limit is 65000. Such a limit was already implemented for Windows with a limit of 1023. Now jdupes.h contains a define to set the hard link limit (1023 for Windows and 65000 for non-windows systems).

b) I observed a segmentation fault in function travdone_free. This was due to a very unbalanced tree, very deep recursions (>50000) and a resulting stack overflow. I implemented a workaround that frees unbranched portions of the tree non-recursively. This reduces the recursion depth in many cases. However, a proper implementation would require a full recursion-free traversal of the tree to always avoid the stack overflow here.
