### PR TITLE
Add missing newline in copyright notice

### DIFF
--- a/jdupes.c
+++ b/jdupes.c
@@ -1868,7 +1868,7 @@ int main(int argc, char **argv)
           c++;
         }
       } else printf(" none");
-      printf("\nCopyright (C) 2015-2020 by Jody Bruchon and contributors");
+      printf("\nCopyright (C) 2015-2020 by Jody Bruchon and contributors\n");
       printf("Forked from fdupes 1.51, (C) 1999-2014 Adrian Lopez and contributors\n");
       printf("\nPermission is hereby granted, free of charge, to any person\n");
       printf("obtaining a copy of this software and associated documentation files\n");


### PR DESCRIPTION
I was seeing something like this when I ran `jdupes -v`:

```
jdupes 1.14.0 (2019-12-30) 64-bit
Compile-time extensions: fsdedup
Copyright (C) 2015-2020 by Jody Bruchon and contributorsForked from fdupes 1.51, (C) 1999-2014 Adrian Lopez and contributors

...
```

Thanks!