### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ option is specified (delete, summarize, link, dedupe, etc.)
                         each set of duplicates and delete the rest without
                         prompting the user
  -o --order=BY          select sort order for output, linking and deleting; by
- -O --paramorder        Parameter order is more important than selected -O sort
                         mtime (BY=time) or filename (BY=name, the default)
+ -O --paramorder        list matches in order specified by command line parameter sequence
+                        Precedence: -o sorts match groups, then -O sorts inside each group
  -p --permissions       don't consider files with different owner/group or
                         permission bits as duplicates
  -P --print=type        print extra info (partial, early, fullhash)

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ option is specified (delete, summarize, link, dedupe, etc.)
  -N --noprompt          together with --delete, preserve the first file in
                         each set of duplicates and delete the rest without
                         prompting the user
- -o --order=BY          select sort order for output, linking and deleting; by
-                        mtime (BY=time) or filename (BY=name, the default)
- -O --paramorder        list matches in order specified by command line parameter sequence
-                        Precedence: -o sorts match groups, then -O sorts inside each group
+ -o --order=BY          select sort order for output, linking and deleting: 
+                        by mtime (BY=time) or filename (BY=name, the default)
+ -O --paramorder        sort output files in order of command line parameter sequence
+                        Parameter order is more important than selected -o sort
+			which applies should several files share the same parameter order
  -p --permissions       don't consider files with different owner/group or
                         permission bits as duplicates
  -P --print=type        print extra info (partial, early, fullhash)


### PR DESCRIPTION
1.fix swapped-lines-typo in manual, introduced on option -o between versions 1.5.1 and 1.6
2.attempt missing descritpion of -O option. Please check/rephrase if unclear or incorrect

Additional request: 
introducing --order=size would be nice. 
This would maximize the space freed by dedupe while minimizing cherry picking time 
during examination of jdupes output before executing a partial dedupe removal