### PR TITLE
Make file specs message not mention a release we've already passed

### DIFF
--- a/jdupes.c
+++ b/jdupes.c
@@ -931,7 +931,7 @@ static void grokdir(const char * const restrict dir,
     goto add_single_file;
 #endif
     fprintf(stderr, "\nFile specs on command line disabled in this version for safety\n");
-    fprintf(stderr, "This should be restored (and safe) in future release v1.16.0\n");
+    fprintf(stderr, "This should be restored (and safe) in a future release\n");
     fprintf(stderr, "See https://github.com/jbruchon/jdupes or email jody@jodybruchon.com\n");
     return; /* Remove when single file is restored */
   }


### PR DESCRIPTION
Tiny change, I know, but it annoyed me greatly every time I saw it.