### PR TITLE
act_printjson: escape 0x80-0xff

### DIFF
--- a/act_printjson.c
+++ b/act_printjson.c
@@ -90,7 +90,7 @@ static void json_escape(const char * restrict string, char * restrict const targ
 	curr = decode_utf8(&string);
 	if (curr == 0xffffffff) break;
 	if (likely(curr < 0xffff)) {
-	  if (likely(curr < 0x20) || curr > 0xff)
+	  if (likely(curr < 0x20) || curr > 0x7f)
 	    escape_uni16((uint16_t)curr, &escaped);
 	  else
 	    *escaped++ = (char)curr;

--- a/act_printjson.c
+++ b/act_printjson.c
@@ -90,7 +90,7 @@ static void json_escape(const char * restrict string, char * restrict const targ
 	curr = decode_utf8(&string);
 	if (curr == 0xffffffff) break;
 	if (likely(curr < 0xffff)) {
-	  if (likely(curr < 0x20) || curr > 0x7f)
+	  if (likely(curr < 0x20 || curr > 0x7f))
 	    escape_uni16((uint16_t)curr, &escaped);
 	  else
 	    *escaped++ = (char)curr;


### PR DESCRIPTION
For some very stupid reason I didn't escape these characters. This would be fine if the output was interpreted as Latin-1, but come on I can't be thinking of that…

Fixes #161