### PR TITLE
Remove the redundant warning for --json

### DIFF
--- a/jdupes.c
+++ b/jdupes.c
@@ -1667,8 +1667,8 @@ static inline void help_text(void)
   printf(" -I --isolate     \tfiles in the same specified directory won't match\n");
 #endif
   printf(" -j --json        \tproduce JSON (machine-readable) output\n");
-/*  printf(" -K --skiphash    \tskip full file hashing (may be faster; 100%% safe)\n"); */
-  printf("                  \tWARNING: in development, not fully working yet!\n");
+/*  printf(" -K --skiphash    \tskip full file hashing (may be faster; 100%% safe)\n");
+    printf("                  \tWARNING: in development, not fully working yet!\n"); */
 #ifndef NO_SYMLINKS
   printf(" -l --linksoft    \tmake relative symlinks for duplicates w/o prompting\n");
 #endif


### PR DESCRIPTION
The warning was introduced for option ```--skiphash ``` in commit 5d98752d5b781be9582dd2e45a4e51f482825283, the said option was removed in commit 6458aba1845b89f1ab8eca8502bfe1cda30c97a7 but the warning stayed.
And, according to commit 07bc17598cc0fd935a10e78e7a0422129dd6acee, the ```--json``` option have been tested so there's no need to repurpose the warning.

Closes #171