### PR TITLE
Cygwin support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,21 +92,21 @@ endif
 UNAME_S=$(shell uname -s)
 
 # MinGW needs this for printf() conversions to work
-ifeq ($(OS), Windows_NT)
-	ifndef NO_UNICODE
-		UNICODE=1
-		COMPILER_OPTIONS += -municode
-		PROGRAM_SUFFIX=.exe
-	endif
-	COMPILER_OPTIONS += -D__USE_MINGW_ANSI_STDIO=1 -DON_WINDOWS=1
-	OBJS += win_stat.o
-	ifeq ($(UNAME_S), MINGW32_NT-5.1)
-		OBJS += winres_xp.o
-	else
-		OBJS += winres.o
-	endif
-	override undefine ENABLE_DEDUPE
-endif
+#ifeq ($(OS), Windows_NT)
+#	ifndef NO_UNICODE
+#		UNICODE=1
+#		COMPILER_OPTIONS += -municode
+#		PROGRAM_SUFFIX=.exe
+#	endif
+#	COMPILER_OPTIONS += -D__USE_MINGW_ANSI_STDIO=1 -DON_WINDOWS=1
+#	OBJS += win_stat.o
+#	ifeq ($(UNAME_S), MINGW32_NT-5.1)
+#		OBJS += winres_xp.o
+#	else
+#		OBJS += winres.o
+#	endif
+#	override undefine ENABLE_DEDUPE
+#endif
 
 # Don't do clonefile on Mac OS X < 10.13 (High Sierra)
 ifeq ($(UNAME_S), Darwin)

--- a/jdupes.c
+++ b/jdupes.c
@@ -65,7 +65,7 @@
 #include "act_summarize.h"
 
 /* Detect Windows and modify as needed */
-#if defined _WIN32 || defined __CYGWIN__
+#if defined _WIN32
  const char dir_sep = '\\';
  #ifdef UNICODE
   const wchar_t *FILE_MODE_RO = L"rbS";
@@ -80,7 +80,7 @@
   #error Do not define UNICODE on non-Windows platforms.
   #undef UNICODE
  #endif
-#endif /* _WIN32 || __CYGWIN__ */
+#endif /* _WIN32 */
 
 /* Windows + Unicode compilation */
 #ifdef UNICODE

--- a/jdupes.h
+++ b/jdupes.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /* Detect Windows and modify as needed */
-#if defined _WIN32 || defined __CYGWIN__
+#if defined _WIN32
  #ifndef ON_WINDOWS
   #define ON_WINDOWS 1
  #endif
@@ -58,7 +58,7 @@ extern "C" {
   #error Do not define UNICODE on non-Windows platforms.
   #undef UNICODE
  #endif
-#endif /* _WIN32 || __CYGWIN__ */
+#endif /* _WIN32 */
 
 /* Windows + Unicode compilation */
 #ifdef UNICODE


### PR DESCRIPTION
Hi,

I wanted to use `jdupes` on cygwin, in order to compile and use it, I had to do two things

1) remove special casing for cygwin in the source code, the Windows and Cygwin structures are not compatible, and I could not see anything that needs special casing for cygwin (the cygwin gcc compiler does not define `_WIN32`)
2) change the makefile, (in particular the GCC version of cygwin does not support `-municode`), as it also handles cygwin as windows. This requires a better solution, but I did not know how to handle it. Any ideas?