### PR TITLE
Build Docker Containers on push to master

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.*
+example_scripts
+testdir

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'github-action'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ env.OWNER_LC }}
+          password: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      -
+        name: Build and push slim
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/slim.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/jdupes:latest
+            ghcr.io/${{ env.OWNER_LC }}/jdupes:${{ github.ref_name }}            
+      -
+        name: Build and push alpine
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/alpine.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/jdupes:alpine
+            ghcr.io/${{ env.OWNER_LC }}/jdupes:${{ github.ref_name }}-alpine

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Usage
 ```
 Usage: jdupes [options] DIRECTORY...
 ```
+### Or with Docker
+```
+docker run -it -v /path/to/dir:/data ghcr.io/jbruchon/jdupes:latest [options] /data
+```
 
 Duplicate file sets will be printed by default unless a different action
 option is specified (delete, summarize, link, dedupe, etc.)

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest as builder
+RUN apk update && apk add --no-cache gcc make musl-dev
+
+COPY . .
+RUN make && make install
+
+FROM alpine:latest as runner
+
+COPY --from=builder /usr/local/bin/jdupes /usr/local/bin/jdupes
+# COPY --from=builder /usr/local/share/man/man1/jdupes.1 /usr/local/share/man/man1/jdupes.1 
+
+ENTRYPOINT [ "/usr/local/bin/jdupes" ]

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -7,6 +7,5 @@ RUN make && make install
 FROM alpine:latest as runner
 
 COPY --from=builder /usr/local/bin/jdupes /usr/local/bin/jdupes
-# COPY --from=builder /usr/local/share/man/man1/jdupes.1 /usr/local/share/man/man1/jdupes.1 
 
 ENTRYPOINT [ "/usr/local/bin/jdupes" ]

--- a/docker/slim.Dockerfile
+++ b/docker/slim.Dockerfile
@@ -6,6 +6,5 @@ RUN make && make install
 FROM debian:bullseye-slim as runner
 
 COPY --from=builder /usr/local/bin/jdupes /usr/local/bin/jdupes
-# COPY --from=builder /usr/local/share/man/man1/jdupes.1 /usr/local/share/man/man1/jdupes.1 
 
 ENTRYPOINT [ "/usr/local/bin/jdupes" ]

--- a/docker/slim.Dockerfile
+++ b/docker/slim.Dockerfile
@@ -1,0 +1,11 @@
+FROM gcc:bullseye as builder
+
+COPY . .
+RUN make && make install
+
+FROM debian:bullseye-slim as runner
+
+COPY --from=builder /usr/local/bin/jdupes /usr/local/bin/jdupes
+# COPY --from=builder /usr/local/share/man/man1/jdupes.1 /usr/local/share/man/man1/jdupes.1 
+
+ENTRYPOINT [ "/usr/local/bin/jdupes" ]


### PR DESCRIPTION
Hi,

I've been using jdupes in containers for a while now and think others could benefit from it as well, which is why I propose the following PR. It automatically builds new Docker images on pushes to master and will make them available on GitHub's Container Registry. This may be expanded to Docker Hub as well, as no jdupes image is available yet.

It builds both an alpine and debian-slim tag:
* ghcr.io/joooostb/jdupes:latest (slim)
* ghcr.io/joooostb/jdupes:alpine

Kind regards,