### PR TITLE
Fix stack size linker option for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,8 @@ endif
 # The ld syntax for Windows is the same for both Cygwin and MinGW
 ifeq ($(OS), Windows_NT)
 COMPILER_OPTIONS += -Wl,--stack=16777216
+else ifeq ($(UNAME_S), Darwin)
+COMPILER_OPTIONS += -Wl,-stack_size -Wl,0x1000000
 else
 COMPILER_OPTIONS += -Wl,-z,stack-size=16777216
 endif


### PR DESCRIPTION
When building jdupes 1.21.0 on macOS, the following error occurs:
```
cc -Wall -Wwrite-strings -Wcast-align -Wstrict-aliasing -Wstrict-prototypes -Wpointer-arith -Wundef -Wshadow -Wfloat-equal -Waggregate-return -Wcast-qual -Wswitch-default -Wswitch-enum -Wconversion -Wunreachable-code -Wformat=2 -std=gnu99 -O2 -g -D_FILE_OFFSET_BITS=64 -fstrict-aliasing -pipe -DSMA_MAX_FREE=11 -DNO_ATIME -DNDEBUG -Wl,-z,stack-size=16777216   -o jdupes jdupes.o jody_paths.o jody_sort.o jody_win_unicode.o jody_strtoepoch.o string_malloc.o oom.o jody_cacheinfo.o act_deletefiles.o act_linkfiles.o act_printmatches.o act_summarize.o act_printjson.o xxhash.o
ld: unknown option: -z
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [jdupes] Error 1
```

Based on [this Stack Overflow answer](https://stackoverflow.com/a/18912422/1609300), the correct flags for macOS linker to use 16MB stack is `-Wl,-stack_size -Wl,0x1000000` (size is given in hexadecimal). In my local testing, this seems to work (build succeeds and the `otool` verification command mentioned in that Stack Overflow answer indeed yields the expected stack size). For reference, this snippet from `man ld` on macOS:
```
-stack_size size
        Specifies the maximum stack size for the main thread in a program.
        Without this option a program has a 8MB stack.  The argument size
        is a hexadecimal number with an optional leading 0x. The size
        should be a multiple of the architecture's page size (4KB or 16KB).
```

There are a few other lesser compatibility/portability concerns in the Makefile with regard to macOS. I haven't included any patches for them but figured it might be worth mentioning here as an aside in case they should be addressed:
- The method to determine `GCCVERSION` may not work on macOS unless the user has explicitly installed `gcc` into their path. By default, Apple's `gcc` is actually `clang` in disguise. For instance, `LC_ALL=C gcc -v 2>&1` yields:
  ```
  Apple clang version 13.1.6 (clang-1316.0.21.2.5)
  Target: x86_64-apple-darwin21.6.0
  Thread model: posix
  [...]
  ```
  Thus the subsequent `grep` filter for `gcc version ` finds no matches and this is recorded in the build log as `expr: syntax error`. This doesn't actually break anything (`gcc` pretending to be `clang` makes `GCCVERSION` irrelevant, anyways), but does print the error message. Just FYI.
- Apple's `clang` sets `-Wunused-command-line-argument` by default, so warnings like these show up whenever we invoke `cc` with `COMPILER_OPTIONS` but are just building an object, not linking:
  ```
  clang: warning: -Wl,-stack_size: 'linker' input unused [-Wunused-command-line-argument]
  clang: warning: -Wl,0x1000000: 'linker' input unused [-Wunused-command-line-argument]
  ```
  The final link step does not generate these warnings, indicating that it accepts the linker inputs. I was able to silence this by adding these flags to `LDFLAGS` instead so that they are only added in the link step and not the compile stage, but have left it as modifying `COMPILER_OPTIONS` for now for consistency with the other branches of the conditional.
- The flags `-Wl,-z,relro` and `-Wl,-z,now` in `ifdef HARDEN` are not compatible with macOS either. I've yet to find an analogue/replacement for such functionality (or if this is even relevant for Mach-O objects). In any case, the hardened configuration does not compile right now on macOS.