### PR TITLE
Ensure the compressed flag is correct after cloning APFS/HFS+ files

### DIFF
--- a/act_linkfiles.c
+++ b/act_linkfiles.c
@@ -248,12 +248,12 @@ extern void linkfiles(file_t *files, const int linktype, const int only_current)
 #else /* ON_WINDOWS */
         if (linktype == 1) {
           if (link(srcfile->d_name, dupelist[x]->d_name) == 0) success = 1;
-#ifdef ENABLE_CLONEFILE_LINK
+ #ifdef ENABLE_CLONEFILE_LINK
         } else if (linktype == 2) {
           if (clonefile(srcfile->d_name, dupelist[x]->d_name, 0) == 0) success = 1;
 	  /* Preserve all file metadata on macOS */
           copyfile(tempname, dupelist[x]->d_name, NULL, COPYFILE_METADATA);
-#endif /* ENABLE_CLONEFILE_LINK */
+ #endif /* ENABLE_CLONEFILE_LINK */
         }
  #ifndef NO_SYMLINKS
         else {

--- a/act_linkfiles.c
+++ b/act_linkfiles.c
@@ -210,7 +210,7 @@ extern void linkfiles(file_t *files, const int linktype, const int only_current)
         /* Assemble a temporary file name */
         strcpy(tempname, dupelist[x]->d_name);
         strcat(tempname, ".__jdupes__.tmp");
-        /* Rename the source file to the temporary name */
+        /* Rename the destination file to the temporary name */
 #ifdef UNICODE
         if (!M2W(tempname, wname2)) {
           fprintf(stderr, "error: MultiByteToWideChar failed: "); fwprint(stderr, srcfile->d_name, 1);


### PR DESCRIPTION
This PR is for the changes that I proposed in #189 a long long time ago.

Compared to my initial implementation, I added a check to see if the flags need to be changed (to prevent needlessly overriding atimes/mtimes), and if they do, I restore the atimes/mtimes of the original dupfile after the call to chflags.