### PR TITLE
Fix build for Hurd 32 bits

### DIFF
--- a/hashdb.c
+++ b/hashdb.c
@@ -27,6 +27,10 @@
 #endif
 #define HT_MASK (HT_SIZE - 1)
 
+#if defined(__GNU__) && !defined(PATH_MAX)
+ #define PATH_MAX 1024
+#endif
+
 static hashdb_t *hashdb[HT_SIZE];
 static int hashdb_init = 0;
 static int hashdb_algo = 0;


### PR DESCRIPTION
Dear @jbruchon,

This commit will fix the build for Hurd 32 bits. This was tested on Debian 12.

The current error is:

hashdb.c:108:19: error: ‘PATH_MAX’ undeclared (first use in this function); did you mean ‘WPATH_MAX’?
